### PR TITLE
Add Robot Page + Home Page Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,23 @@
 Snider CS Website
 
 ## Clone
-```
+```bash
 git clone git@github.com:snidercs/website-static
 cd website-static
 git submodule update --init
 ```
 
+## Theme Features and Help
+https://github.com/adityatelange/hugo-PaperMod/wiki/Features
+
 ## Useful Hugo commands
 
 Hugo will create the dir and MD. Hugo will also populate the MD file with datetime of creation.
-```
+```bash
 hugo new content <dir>/example.md
 ```
 Start up the Hugo website with
+```bash
+hugo server -D
 ```
-Hugo server -D
-```
--D flag means Hugo will also generate MD files with draft = true.
+The `-D` flag means Hugo will also generate MD files with draft = true.

--- a/assets/css/extended/theme-vars.css
+++ b/assets/css/extended/theme-vars.css
@@ -1,0 +1,4 @@
+
+:root {
+    --main-width: 960px;
+}

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,3 +1,25 @@
+---
+params:
+  profileMode:
+    enabled: true
+    title: "<Title>" # optional default will be site title
+    subtitle: "This is subtitle"
+    imageUrl: "<image link>" # optional
+    imageTitle: "<title of image as alt>" # optional
+    imageWidth: 120 # custom size
+    imageHeight: 120 # custom size
+    buttons:
+      - name: Archive
+        url: "/posts"
+      - name: Github
+        url: "https://github.com/snidercs"
+
+#   socialIcons: # optional
+#     - name: "instagram"
+#       url: "<link>"
+
+---
+
 # SNIDER CS
 
-This is the FWCS Snider Computer Science page. 
+This is the FWCS Snider Computer Science page.

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,25 +1,3 @@
----
-params:
-  profileMode:
-    enabled: true
-    title: "<Title>" # optional default will be site title
-    subtitle: "This is subtitle"
-    imageUrl: "<image link>" # optional
-    imageTitle: "<title of image as alt>" # optional
-    imageWidth: 120 # custom size
-    imageHeight: 120 # custom size
-    buttons:
-      - name: Archive
-        url: "/posts"
-      - name: Github
-        url: "https://github.com/snidercs"
-
-#   socialIcons: # optional
-#     - name: "instagram"
-#       url: "<link>"
-
----
-
 # SNIDER CS
 
 This is the FWCS Snider Computer Science page.

--- a/content/robot/_index.md
+++ b/content/robot/_index.md
@@ -1,0 +1,49 @@
+---
+linkTitle: Robot
+title:  Robot - FRC 2024
+date:   2024-03-11T18:36:45-04:00
+draft:  false
+menu:
+  main:
+    identifier: robot
+    weight: 1
+---
+
+### Robot Features
+* Differential drive
+* Front mount camera
+* More....
+
+### Firmware Features
+* Languages: C++ and Lua.
+* Smart confguration file via Lua.
+* Ultra low latency TimedRobot base.
+* Fast code deploys when only Lua code changes.
+* Unit Testing of primary bot functions.
+* Unit Testing of Lua/C++ bindings.
+
+### Gamepad Layout
+X Box controller mapping.  Controls not listed are not in use.
+|  Button/Stick |             Action          |
+|---------------|:---------------------------:|
+| Left Axis     | Forward and backward motion |
+| Right Axis    | Rotation                    |
+| Left Bumper   | Note intake                 |
+| Right Bumper  | Note shooting               |
+| Right Trigger | Brake                       |
+| X             | Arm up                      |
+| A             | Arm down                    |
+
+### Motor Controllers
+Motor controllers used in all moving parts.
+| Label | Controller | For?                         |
+|-------|:----------:|------------------------------|
+| M1    | SparkMax   | Drivetrain primary (left)    |
+| M2    | SparkMax   | Drivetrain primary (right)   |
+| M3    | SparkMax   | Drivetrain secondary (left)  |
+| M4    | SparkMax   | Drivetrain secondary (right) |
+| M5    | SparkMax   | Lifter arm (left)            |
+| M5    | SparkMax   | Lifter arm (right)           |
+| M5    | SparkMax   | Shooter main (top)           |
+| M5    | SparkMax   | Shooter main (bottom)        |
+| M5    | SparkMax   | Shooter support              |

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,0 @@
-baseURL = 'https://example.org/'
-languageCode = 'en-us'
-title = 'Snider CS Homepage'
-theme = 'PaperModX'

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,0 +1,22 @@
+baseURL: 'https://example.org/'
+languageCode: en-us
+title: Snider CS
+theme: PaperModX
+params:
+  profileMode:
+    enabled: true
+    title: "Snider" # optional default will be site title
+    subtitle: "Computer science..."
+    imageUrl: "https://avatars.githubusercontent.com/u/157931423?s=400&u=d4d289dd78a0fc8bf066958df44269f82fafeca3&v=4" # optional
+    # imageTitle: "<title of image as alt>" # optional
+    imageWidth: 256 # custom size
+    imageHeight: 256 # custom size
+    buttons:
+      - name: News
+        url: "/posts"
+      - name: Github
+        url: "https://github.com/snidercs"
+
+  socialIcons: # optional
+    - name: "instagram"
+      url: "https://instagram.com"

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -19,4 +19,4 @@ params:
 
   socialIcons: # optional
     - name: "instagram"
-      url: "https://instagram.com"
+      url: "https://www.instagram.com/snider_robotics9431/"


### PR DESCRIPTION
See endpoint.  `/robot/`.  The homepage now displays a snider logo with buttons to other pages + social links.  Profile settings can be changed in `hugo.yaml`

The instagram link is wrong, but I know we have one.